### PR TITLE
Fix "Single Frame" mode not working.

### DIFF
--- a/flxanimate/animate/FlxSymbol.hx
+++ b/flxanimate/animate/FlxSymbol.hx
@@ -131,6 +131,9 @@ class FlxSymbol
     }
     public function frameControl(frame:Int, loopType:LoopType)
     {
+	if ([singleframe, "singleframe"].indexOf(loopType) != -1)
+		return frame;
+	
         if (frame < 0)
 		{
 			if ([loop, "loop"].indexOf(loopType) != -1)

--- a/flxanimate/animate/FlxSymbol.hx
+++ b/flxanimate/animate/FlxSymbol.hx
@@ -131,8 +131,8 @@ class FlxSymbol
     }
     public function frameControl(frame:Int, loopType:LoopType)
     {
-	if ([singleframe, "singleframe"].indexOf(loopType) != -1)
-		return frame;
+        if ([singleframe, "singleframe"].indexOf(loopType) != -1)
+            return frame;
 	
         if (frame < 0)
 		{


### PR DESCRIPTION
Let's say you have a sprite. One of it's animated pieces use a single symbol with a bunch of various poses and shapes, often variating heavily and relying on single frame mode to allow them to specify a drawing.
You finish your animation and export it as a Texture Atlas, utilizing this library. One problem, though!
All of the symbols you marked as "Single Frame" are now stuck on frame 0, causing you to either have to separate each hand into different symbols (which is bad), or hit break apart on every frame (which is even worse).

This PR simply adds the return for the specified frame to be used in SF mode, allowing for usage of such symbols.

In other words, I'm just allowing you to use a basic Adobe Animate symbol animation technique.