### PR TITLE
Fix FlxAnimate sprites not rendering correctly on multiple cameras

### DIFF
--- a/flxanimate/FlxAnimate.hx
+++ b/flxanimate/FlxAnimate.hx
@@ -212,10 +212,10 @@ class FlxAnimate extends FlxSprite
 	{
 		if (alpha == 0 || colorTransform != null && (colorTransform.alphaMultiplier == 0 || colorTransform.alphaOffset == -255) || limb == null || limb.type == EMPTY)
 			return;
-		var matrix = new FlxMatrix();
-		matrix.concat(_matrix);
 		for (camera in cameras)
 		{
+			var matrix = new FlxMatrix();
+			matrix.concat(_matrix);
 			if (!camera.visible || !camera.exists || !limbOnScreen(limb, _matrix, camera))
 				return;
 			


### PR DESCRIPTION
Simple fix that allows you to draw the same FlxAnimate sprite on multiple cameras, without it breaking when cameras have different scroll values.