### PR TITLE
onComplete runs even when loopType is loop, and setTheSettings change

### DIFF
--- a/flxanimate/FlxAnimate.hx
+++ b/flxanimate/FlxAnimate.hx
@@ -334,7 +334,7 @@ class FlxAnimate extends FlxSprite
 		anim.buttonMap.set(button, {Callbacks: callbacks, #if FLX_SOUND_SYSTEM Sound:  sound #end});
 	}
 
-	function setTheSettings(?Settings:Settings):Void
+	public function setTheSettings(?Settings:Settings):Void
 	{
 		@:privateAccess
 		if (true)

--- a/flxanimate/animate/FlxAnim.hx
+++ b/flxanimate/animate/FlxAnim.hx
@@ -194,11 +194,13 @@ class FlxAnim implements IFlxDestroyable
 
 
 		
-		if (finished)
+		if (finished || curFrame == curSymbol.length - 1)
 		{
 			if (onComplete != null)
 				onComplete();
-			pause();
+			
+			if (loopType == PlayOnce)
+				pause();
 		}
 	}
 	function get_finished()

--- a/flxanimate/animate/FlxAnim.hx
+++ b/flxanimate/animate/FlxAnim.hx
@@ -194,7 +194,7 @@ class FlxAnim implements IFlxDestroyable
 
 
 		
-		if (finished || curFrame == curSymbol.length - 1)
+		if (finished || curFrame == (reversed ? 0 : curSymbol.length - 1))
 		{
 			if (onComplete != null)
 				onComplete();


### PR DESCRIPTION
pretty easy to parse through the changes, made it so that onComplete even runs / triggers when the animation is looping, which I think is generally reasonable to have!

also turned `setTheChanges` function to public since it might be nice to change it on the fly?