### PR TITLE
Fix error, while building with flixel 5.3 or higher

### DIFF
--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -139,6 +139,19 @@ class FlxAnimateFrames extends FlxAtlasFrames
         }
         return frames;
     }
+    #if (flixel > "5.2") 
+    public override function concat(collection:FlxAtlasFrames, overwriteHash:Bool = false):FlxAtlasFrames
+    {
+        if (parents.indexOf(collection.parent) == -1)
+            parents.push(collection.parent);
+        for (frame in collection.frames)
+        {
+            this.frames.push(frame);
+            framesHash.set(frame.name, frame);
+        }
+        return this;
+    }
+    #else
     public function concat(frames:FlxFramesCollection)
     {
         if (parents.indexOf(frames.parent) == -1)
@@ -149,6 +162,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
             framesHash.set(frame.name, frame);
         }
     }
+    #end
     /**
      * Sparrow spritesheet format parser with support of both of the versions and making the image completely optional to you.
      * @param Path The direction of the Xml you want to parse.

--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -139,7 +139,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
         }
         return frames;
     }
-    #if (flixel > "5.2") 
+    #if (flixel >= "5.3.0") 
     public override function concat(collection:FlxAtlasFrames, overwriteHash:Bool = false):FlxAtlasFrames
     {
         if (parents.indexOf(collection.parent) == -1)


### PR DESCRIPTION
Fix for that errors
```
C:/HaxeToolkit/haxe/lib/flxanimate/git/flxanimate/frames/FlxAnimateFrames.hx:142: characters 21-27 : Field concat should be declared with 'override' since it is inherited from superclass flixel.graphics.frames.FlxAtlasFrames
C:/HaxeToolkit/haxe/lib/flxanimate/git/flxanimate/frames/FlxAnimateFrames.hx:142: characters 21-27 : Field concat overrides parent class with different or incomplete type
C:/HaxeToolkit/haxe/lib/flixel/5,4,1/flixel/graphics/frames/FlxAtlasFrames.hx:457: characters 18-24 : ... Base field is defined here
C:/HaxeToolkit/haxe/lib/flxanimate/git/flxanimate/frames/FlxAnimateFrames.hx:142: characters 21-27 : ... Different number of function arguments
```