### PR TITLE
upkeep for recent flixel changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 samples/flixel/export/
+.vscode

--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -27,15 +27,20 @@ import flixel.graphics.frames.FlxFrame;
 
 class FlxAnimateFrames extends FlxAtlasFrames
 {
-    public function new()
+    #if (flixel < "5.4.0")
+    public var parents:Array<FlxGraphic>;
+    
+    public function new(parent:FlxGraphic, ?border:FlxPoint)
     {
-        super(null);
-        parents = [];
+        parents = [parent];
+        super(parent, border);
     }
+    #end
+    
     static var data:AnimateAtlas = null;
     static var zip:Null<List<haxe.zip.Entry>>;
 
-    public var parents:Array<FlxGraphic>;
+    
     /**
      * Parses the spritemaps into small sprites to use in the animation.
      * 
@@ -44,7 +49,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
      */
     public static function fromTextureAtlas(Path:String):FlxAtlasFrames
     {
-        var frames:FlxAnimateFrames = new FlxAnimateFrames();
+        var frames:FlxAnimateFrames = null;
         
         if (zip != null || haxe.io.Path.extension(Path) == "zip")
         {
@@ -73,6 +78,8 @@ class FlxAnimateFrames extends FlxAtlasFrames
                 var curImage = BitmapData.fromBytes(imagemap[curJson.meta.image]);
                 if (curImage != null)
                 {
+                    var graphic = FlxG.bitmap.add(curImage);
+                    frames = new FlxAnimateFrames(graphic);
                     for (sprites in curJson.ATLAS.SPRITES)
                     {
                         frames.pushFrame(textureAtlasHelper(curImage, sprites.SPRITE, curJson.meta));
@@ -95,14 +102,14 @@ class FlxAnimateFrames extends FlxAtlasFrames
                     var spritemapFrames = FlxAtlasFrames.findFrame(graphic);
                     if (spritemapFrames == null)
                     {
-                        spritemapFrames = new FlxAnimateFrames();
+                        spritemapFrames = new FlxAnimateFrames(graphic);
                         for (curSprite in curJson.ATLAS.SPRITES)
                         {
                             spritemapFrames.pushFrame(textureAtlasHelper(graphic.bitmap,curSprite.SPRITE, curJson.meta));
                         }
                     }
                     graphic.addFrameCollection(spritemapFrames);
-                    frames.concat(spritemapFrames);
+                    frames.addAtlas(spritemapFrames);
                 }
                 else
                     FlxG.log.error('the image called "${curJson.meta.image}" does not exist in Path $Path, maybe you changed the image Path somewhere else?');
@@ -118,14 +125,16 @@ class FlxAnimateFrames extends FlxAtlasFrames
                     var spritemapFrames = FlxAtlasFrames.findFrame(graphic);
                     if (spritemapFrames == null)
                     {
-                        spritemapFrames = new FlxAnimateFrames();
+                        spritemapFrames = new FlxAnimateFrames(graphic);
                         for (curSprite in curJson.ATLAS.SPRITES)
                         {
                             spritemapFrames.pushFrame(textureAtlasHelper(graphic.bitmap,curSprite.SPRITE, curJson.meta));
                         }
                     }
                     graphic.addFrameCollection(spritemapFrames);
-                    frames.concat(spritemapFrames);
+                    if (frames == null)
+                        frames = new FlxAnimateFrames(graphic);
+                    frames.addAtlas(spritemapFrames);
                 }
                 else
                     FlxG.log.error('the image called "${curJson.meta.image}" does not exist in Path $Path, maybe you changed the image Path somewhere else?');
@@ -139,28 +148,17 @@ class FlxAnimateFrames extends FlxAtlasFrames
         }
         return frames;
     }
-    #if (flixel >= "5.3.0") 
-    public override function concat(collection:FlxFramesCollection, overwriteHash:Bool = false):FlxAtlasFrames
+    #if (flixel < "5.4.0")
+    public function addAtlas(collection:FlxFramesCollection, overwriteHash:Bool = false):FlxAtlasFrames
     {
+        if (collection.parent == null)
+            throw "Cannot add atlas with null parent";
+        
         if (parents.indexOf(collection.parent) == -1)
             parents.push(collection.parent);
         for (frame in collection.frames)
-        {
-            this.frames.push(frame);
-            framesHash.set(frame.name, frame);
-        }
+            pushFrame(frame);
         return this;
-    }
-    #else
-    public function concat(frames:FlxFramesCollection)
-    {
-        if (parents.indexOf(frames.parent) == -1)
-            parents.push(frames.parent);
-        for (frame in frames.frames)
-        {
-            this.frames.push(frame);
-            framesHash.set(frame.name, frame);
-        }
     }
     #end
     /**

--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -148,7 +148,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
         }
         return frames;
     }
-    #if (flixel < "5.4.0")
+	
     public function addAtlas(collection:FlxFramesCollection, overwriteHash:Bool = false):FlxAtlasFrames
     {
         if (collection.parent == null)
@@ -160,7 +160,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
             pushFrame(frame);
         return this;
     }
-    #end
+	
     /**
      * Sparrow spritesheet format parser with support of both of the versions and making the image completely optional to you.
      * @param Path The direction of the Xml you want to parse.

--- a/samples/flixel/source/Main.hx
+++ b/samples/flixel/source/Main.hx
@@ -13,7 +13,7 @@ class Main extends Sprite
 	{
 		super();
 
-		addChild(new FlxGame(1280, 720, PlayState, 1, framerate, framerate, true, false));
+		addChild(new FlxGame(1280, 720, PlayState, #if (flixel < "5.0.0") 1,#end framerate, framerate, true, false));
 
 		var fpsCounter = new FPS(10, 3, FlxColor.BLACK);
 		addChild(fpsCounter);

--- a/samples/flixel/source/PlayState.hx
+++ b/samples/flixel/source/PlayState.hx
@@ -25,7 +25,7 @@ class PlayState extends FlxState
 
 	override public function update(elapsed:Float)
 	{
-		if (FlxG.keys.justPressed.SPACE)
+		if (FlxG.keys.justPressed.SPACE || FlxG.mouse.pressed)
 		{
 			if (!char.anim.isPlaying)
 				char.anim.play();
@@ -33,13 +33,22 @@ class PlayState extends FlxState
 				char.anim.pause();
 		}
 
-		char.x = FlxG.mouse.x;
-		char.y = FlxG.mouse.y;
+		char.x = FlxG.mouse.x - 300;
+		char.y = FlxG.mouse.y - 300;
 
 		if (FlxG.keys.justPressed.E)
 			FlxG.camera.zoom += 0.25;
 		if (FlxG.keys.justPressed.Q)
 			FlxG.camera.zoom -= 0.25;
+		
+		if (FlxG.mouse.wheel != 0)
+			FlxG.camera.zoom += FlxG.mouse.wheel * #if html5 1 #else 0.02 #end;
+		
+		if (FlxG.camera.zoom < 0.5)
+			FlxG.camera.zoom = 0.5;
+		
+		if (FlxG.camera.zoom > 2.0)
+			FlxG.camera.zoom = 2.0;
 
 		super.update(elapsed);
 	}


### PR DESCRIPTION
I've been told that some people are not updating their flixel version because of FlxAnimate having incompatibility issues

You incorrectly override `concat` for flixel versions < 5.3.0, but `concat` was introduced in flixel 5.4.0, meaning people using flixel 5.3.0 and 5.3.1 would get errors.

with this change, on the flixel versions 5.4.0 or later, FlxAnimateFrames no longer use the `parents` field. It was never really used, anyway, at least in the sample, and it combines atlases using FlxAtlasFrame's `addAtlas` function, which is more funtionally similar to what FlxAnimate's `concat` function did than FlxAtlasFrame's `concat` (We follow Array's concat, which creates a new instance containing both, rather than adding all elements from one to the other)

I also spruced up the demo a little and fixed an error in Main.hx