### PR TITLE
Fix crashes & remove leftover debugging

### DIFF
--- a/flxanimate/FlxAnimate.hx
+++ b/flxanimate/FlxAnimate.hx
@@ -85,7 +85,7 @@ class FlxAnimate extends FlxSprite
 	{
 		super(X, Y);
 		anim = new FlxAnim(this);
-		showPivot = #if debug false #else false #end;
+		showPivot = false;
 		if (Path != null)
 			loadAtlas(Path);
 		if (Settings != null)

--- a/flxanimate/animate/FlxAnim.hx
+++ b/flxanimate/animate/FlxAnim.hx
@@ -292,7 +292,7 @@ class FlxAnim implements IFlxDestroyable
 	}
 	function get_curFrame()
 	{
-		return (curSymbol != null) ? curSymbol.curFrame : null;
+		return (curSymbol != null) ? curSymbol.curFrame : 0;
 	}
 	function set_curFrame(Value:Int)
 	{

--- a/flxanimate/animate/FlxLayer.hx
+++ b/flxanimate/animate/FlxLayer.hx
@@ -276,8 +276,6 @@ class FlxLayer extends FlxObject implements IFilterable
             return;
         }
         
-        trace(_currFrame);
-        
         if (_currFrame != null)
         {
             if (frame >= _currFrame.index && frame < _currFrame.duration) return;

--- a/flxanimate/data/AnimationData.hx
+++ b/flxanimate/data/AnimationData.hx
@@ -582,7 +582,6 @@ abstract SymbolInstance({}) from {}
 	function get_FF()
 	{
 		var ff = AnimationData.setFieldBool(this, ["FF", "firstFrame"]);
-		trace(ff);
 		return (ff == null) ? 0 : ff;
 	}
 


### PR DESCRIPTION
This fixes a crash on the dev branch caused by trying to return null when an int was expected, also removes some leftover traces that caused the game to run at a very slow framerate