### PR TITLE
change the flxelement json parsing so we dont need an array sort

### DIFF
--- a/flxanimate/animate/FlxElement.hx
+++ b/flxanimate/animate/FlxElement.hx
@@ -154,10 +154,26 @@ class FlxElement extends FlxObject implements IFlxDestroyable
 		}
 
 		var m3d = (symbol) ? element.SI.M3D : element.ASI.M3D;
-		var array = Reflect.fields(m3d);
-		if (!Std.isOfType(m3d, Array))
-			array.sort((a, b) -> Std.parseInt(a.substring(1)) - Std.parseInt(b.substring(1)));
-		var m:Array<Float> = (m3d is Array) ? m3d : [for (field in array) Reflect.field(m3d,field)];
+		var m:Array<Float> = [];
+
+		if (m3d == null)
+		{
+			// Initialize with identity matrix if m3d is null
+    	m = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+		}
+		else if (Std.isOfType(m3d, Array))
+		{
+    	m = cast m3d;
+		}
+		else
+		{
+    	// Assuming m3d is an object with properties m00, m01, m02, etc.
+			var rowColNames = ["00", "01", "02", "03", "10", "11", "12", "13", "20", "21", "22", "23", "30", "31", "32", "33"];
+			for (i in 0...16) {
+					var fieldName = 'm${rowColNames[i]}';
+					m[i] = Reflect.hasField(m3d, fieldName) ? Reflect.field(m3d, fieldName) : 0;
+			}
+		}
 
 		if (!symbol && m3d == null)
 		{
@@ -165,7 +181,7 @@ class FlxElement extends FlxObject implements IFlxDestroyable
 			m[1] = m[4] = m[12] = m[13] = 0;
 		}
 
-		var pos = (symbol) ? element.SI.bitmap.POS : element.ASI.POS;
+		var pos = symbol ? element.SI.bitmap.POS : element.ASI.POS;
 		if (pos == null)
 			pos = {x: 0, y: 0};
 		return new FlxElement((symbol) ? element.SI.bitmap.N : element.ASI.N, params, new FlxMatrix(m[0], m[1], m[4], m[5], m[12] + pos.x, m[13] + pos.y));


### PR DESCRIPTION
In current implementation, we do a an array sort to help with parsing "verbose" animation.json files, which output their Matrix3D as a dynamic object (`"Matrix3d": {"m01": 0.1, ...}`) rather than a simple (pre sorted) array (`"M3D": [0.1, 0.0, 0.0, ...]`).

The array sorting is a bit inefficient, this PR cleans up the `.fromJson()` function to properly initialize the "verbose" matrix3D's

re: performance / optimization
Using `Instruments` on Mac, the `array.sort()` based method would "hang" (do so much processing that the game would freeze) for `3.65s` when entering Freeplay

This PR would "hang" for only 2.49s when entering freeplay.

I don't believe I've ran into any visual issues with this