### PR TITLE
Fix path in include.xml

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
+<project xmlns="http://lime.openfl.org/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://lime.openfl.org/project/1.0.4 http://lime.openfl.org/xsd/project-1.0.4.xsd">
 
     <assets path="assets/images/pivot.png" rename="flxanimate/images/pivot.png" embed="true" />
     <assets path="assets/images/indicator.png" rename="flxanimate/images/indicator.png" embed="true" />


### PR DESCRIPTION
Replaces the dead `lime.software` domain with the new `lime.openfl.org` domain and bumps the version