### PR TITLE
Use `haxe.io.Path.normalize()` instead of `.split('\\').join('/')` in `FlxAnimateFrames.hx`

### DIFF
--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -96,7 +96,7 @@ class FlxAnimateFrames extends FlxAtlasFrames
 
 		if (Path is String)
 		{
-			var str:String = cast(Path, String).split("\\").join("/");
+			var str:String = haxe.io.Path.normalize(cast(Path, String));
 			var text = (StringTools.contains(str, "/")) ? Assets.getText(str) : str;
 			json = haxe.Json.parse(text.split(String.fromCharCode(0xFEFF)).join(""));
 		}


### PR DESCRIPTION
Very small and likely doesn't have any side effects, but I think it's a cleaner function that avoids turning the string into an array and back