### PR TITLE
Fix the anims not having timeScale applied correctly

### DIFF
--- a/flxanimate/animate/FlxAnim.hx
+++ b/flxanimate/animate/FlxAnim.hx
@@ -396,7 +396,7 @@ class FlxAnim implements IFlxDestroyable
 			curInstance.updateRender(elapsed * timeScale #if (flixel >= "5.5.0") * FlxG.animationTimeScale #end, curFrame, symbolDictionary, swfRender);
 		if (frameDelay == 0 || !isPlaying || finished) return;
 
-		_tick += elapsed;
+		_tick += elapsed * timeScale #if (flixel >= "5.5.0") * FlxG.animationTimeScale #end;
 
 		while (_tick > frameDelay)
 		{


### PR DESCRIPTION
Was fuckin' around w/ timeScale for the editor i was cooking for funkin and i noticed that timeScale wasn't doing it's thing on FlxAnimate objects - lo and behold it doesn't get applied to the other time elapsed gets brought up in FlxAnim, so this PR fixes that lol!