### PR TITLE
Skip rasterizing gpu-supported blends

### DIFF
--- a/flxanimate/animate/FlxLayer.hx
+++ b/flxanimate/animate/FlxLayer.hx
@@ -390,7 +390,7 @@ class FlxLayer extends FlxObject implements IFilterable
 	public static function fromJSON(layer:Layers)
 	{
 		if (layer == null) return null;
-		var frames = [];
+		//var frames = [];
 		var l = new FlxLayer(layer.LN);
 		if (layer.LT != null || layer.Clpb != null)
 		{
@@ -410,7 +410,7 @@ class FlxLayer extends FlxObject implements IFilterable
 	public static function fromJSONEx(layer:Layers)
 	{
 		if (layer == null) return null;
-		var frames = [];
+		//var frames = [];
 		var l = new FlxLayer(layer.LN);
 		if (layer.LT != null || layer.Clpb != null)
 		{

--- a/flxanimate/animate/FlxSymbolDictionary.hx
+++ b/flxanimate/animate/FlxSymbolDictionary.hx
@@ -126,7 +126,6 @@ class FlxSymbolDictionary
 
 	public function fromJSONEx(animation:AnimAtlas)
 	{
-		trace(animation.AN.SN);
 		addSymbol(new FlxSymbol(animation.AN.SN, FlxTimeline.fromJSONEx(animation.AN.TL)));
 
 		if (animation.SD != null)

--- a/flxanimate/animate/SymbolParameters.hx
+++ b/flxanimate/animate/SymbolParameters.hx
@@ -303,16 +303,21 @@ class SymbolParameters implements IFilterable
 
 	function set_blendMode(value:BlendMode)
 	{
+		if (type == Graphic) return blendMode = NORMAL;
+
 		if (value == null)
 			value = NORMAL;
-
-		if (type == Graphic) return blendMode = NORMAL;
 
 		if (blendMode != value)
 		{
 			blendMode = value;
-			if (blendMode != NORMAL && _filterFrame == null)
-				_renderDirty = true;
+			
+			switch (value) {
+				case NORMAL | ADD | /*DIFFERENCE | INVERT |*/ MULTIPLY | SCREEN | SUBTRACT:
+				default: // only rasterize non gpu supported blends
+					if (_filterFrame == null)
+						_renderDirty = true;
+			}
 		}
 		return value;
 	}
@@ -321,8 +326,14 @@ class SymbolParameters implements IFilterable
 	{
 		if (type == Graphic) return false;
 
+		if (filters != null && filters.length > 0)
+			return true;
 
-		if (filters != null && filters.length > 0 || blendMode != NORMAL) return true;
+		switch (blendMode) {
+			case NORMAL | ADD | /*DIFFERENCE | INVERT |*/ MULTIPLY | SCREEN | SUBTRACT:
+			default: // only rasterize non gpu supported blends
+				return true;
+		}
 
 		return _cacheAsBitmap;
 	}

--- a/flxanimate/data/AnimationData.hx
+++ b/flxanimate/data/AnimationData.hx
@@ -1,5 +1,6 @@
 package flxanimate.data;
 
+import openfl.display.BlendMode;
 import flxanimate.effects.*;
 import flxanimate.motion.AdjustColor;
 import flixel.util.FlxDirection;
@@ -586,7 +587,7 @@ abstract SymbolInstance({}) from {}
 	 */
 	public var bitmap(get, never):Bitmap;
 
-	public var B(get, never):String;
+	public var B(get, never):BlendMode;
 
 	/**
 	 * this sets on which frame it's the symbol, Graphic only


### PR DESCRIPTION
Theres some openfl blend modes supported on gpu rendering that can be used to skip rasterizing some blends
This PR works for ADD, MULTIPLY, SCREEN and SUBTRACT blend modes