### PR TITLE
Fix `SymbolParameters` & `FlxLayer` destroy taking a long time

### DIFF
--- a/flxanimate/animate/FlxLayer.hx
+++ b/flxanimate/animate/FlxLayer.hx
@@ -104,9 +104,9 @@ class FlxLayer extends FlxObject implements IFilterable
 		_filterFrame = FlxDestroyUtil.destroy(_filterFrame);
 		_filterCamera = FlxDestroyUtil.destroy(_filterCamera);
 		_filterMatrix = null;
-		FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp1));
+		if (_bmp1 != null) FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp1));
 		_bmp1 = FlxDestroyUtil.dispose(_bmp1);
-		FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp2));
+		if (_bmp2 != null) FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp2));
 		_bmp2 = FlxDestroyUtil.dispose(_bmp2);
 
 		for (keyframe in _keyframes)

--- a/flxanimate/animate/SymbolParameters.hx
+++ b/flxanimate/animate/SymbolParameters.hx
@@ -156,9 +156,9 @@ class SymbolParameters implements IFilterable
 		_filterFrame = FlxDestroyUtil.destroy(_filterFrame);
 		_filterCamera = FlxDestroyUtil.destroy(_filterCamera);
 		_filterMatrix = null;
-		FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp1));
+		if (_bmp1 != null) FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp1));
 		_bmp1 = FlxDestroyUtil.dispose(_bmp1);
-		FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp2));
+		if (_bmp2 != null) FlxG.bitmap.removeByKey(FlxG.bitmap.findKeyForBitmap(_bmp2));
 		_bmp2 = FlxDestroyUtil.dispose(_bmp2);
 	}
 


### PR DESCRIPTION
This fixes this issue in FNF: https://github.com/FunkinCrew/Funkin/issues/3178

If the bitmaps were null it would still attempt to search for them which would take forever depending on the cache's size.
This is the simplest way to solve it though I think what's done [here](https://github.com/NotHyper-474/flxanimate-contribute/commit/6830c8d31d00e6bc81c040944f77c49bf1a10146) or [here](https://github.com/NotHyper-474/flxanimate-contribute/commit/2421169a47b5e1bd30df853bb3a297b0cc09ee0e) is preferable instead.