### PR TITLE
Remove deprecated calls to ``symbolDictionary``

### DIFF
--- a/flxanimate/FlxAnimate.hx
+++ b/flxanimate/FlxAnimate.hx
@@ -319,7 +319,7 @@ class FlxAnimate extends FlxSprite
 		colorEffect.__copyFrom(colorFilter);
 
 
-		var symbol = (instance.symbol != null) ? anim.symbolDictionary.get(instance.symbol.name) : null;
+		var symbol = (instance.symbol != null) ? anim.library.getSymbol(instance.symbol.name) : null;
 
 		if (instance.bitmap == null && symbol == null)
 			return;

--- a/flxanimate/animate/FlxElement.hx
+++ b/flxanimate/animate/FlxElement.hx
@@ -81,13 +81,14 @@ class FlxElement extends FlxObject implements IFlxDestroyable
 		matrix = null;
 	}
 
-	public function updateRender(elapsed:Float, curFrame:Int, dictionary:Map<String, FlxSymbol>, ?swfRender:Bool = false)
+	public function updateRender(elapsed:Float, curFrame:Int, dictionary:FlxSymbolDictionary, ?swfRender:Bool = false)
 	{
 		update(elapsed);
 
-		if (symbol != null && dictionary.exists(symbol.name))
+		if (symbol != null && dictionary.existsSymbol(symbol.name))
 		{
-			var length = dictionary[symbol.name].length;
+			var parentSymbol =  dictionary.getSymbol(symbol.name);
+			var length = parentSymbol.length;
 			var curFF = curFrame + symbol.firstFrame;
 			
 			curFF = switch (symbol.loop)
@@ -104,7 +105,8 @@ class FlxElement extends FlxObject implements IFlxDestroyable
 				symbol._renderDirty = false;
 				_parent._renderDirty = true;
 			}
-			dictionary[symbol.name].updateRender(elapsed, curFF, dictionary, swfRender);
+
+			parentSymbol.updateRender(elapsed, curFF, dictionary, swfRender);
 		}
 	}
 

--- a/flxanimate/animate/FlxKeyFrame.hx
+++ b/flxanimate/animate/FlxKeyFrame.hx
@@ -110,7 +110,7 @@ class FlxKeyFrame
 			}
 		}
 	}
-	public function updateRender(elapsed:Float, curFrame:Int, dictionary:Map<String, FlxSymbol>, ?swfRender:Bool = false)
+	public function updateRender(elapsed:Float, curFrame:Int, dictionary:FlxSymbolDictionary, ?swfRender:Bool = false)
 	{
 		var curFrame = curFrame - index;
 

--- a/flxanimate/animate/FlxLayer.hx
+++ b/flxanimate/animate/FlxLayer.hx
@@ -116,7 +116,7 @@ class FlxLayer extends FlxObject implements IFilterable
 		_keyframes = null;
 	}
 
-	public function updateRender(elapsed:Float, curFrame:Int, dictionary:Map<String, FlxSymbol>, ?swfRender:Bool = false)
+	public function updateRender(elapsed:Float, curFrame:Int, dictionary:FlxSymbolDictionary, ?swfRender:Bool = false)
 	{
 		update(elapsed);
 		var _prevFrame = _currFrame;

--- a/flxanimate/animate/FlxSymbol.hx
+++ b/flxanimate/animate/FlxSymbol.hx
@@ -214,7 +214,7 @@ class FlxSymbol implements IFlxDestroyable
 		return frame;
 	}
 
-	public inline function updateRender(elapsed:Float, curFrame:Int, dictionary:Map<String, FlxSymbol>, ?swfRender:Bool = false)
+	public inline function updateRender(elapsed:Float, curFrame:Int, dictionary:FlxSymbolDictionary, ?swfRender:Bool = false)
 	{
 		timeline.updateRender(elapsed, curFrame, dictionary, swfRender);
 	}

--- a/flxanimate/animate/FlxTimeline.hx
+++ b/flxanimate/animate/FlxTimeline.hx
@@ -155,7 +155,7 @@ class FlxTimeline implements IFlxDestroyable
 		return layer;
 	}
 
-	public inline function updateRender(elapsed:Float, curFrame:Int, dictionary:Map<String, FlxSymbol>, ?swfRender:Bool = false)
+	public inline function updateRender(elapsed:Float, curFrame:Int, dictionary:FlxSymbolDictionary, ?swfRender:Bool = false)
 	{
 		for (layer in _layers)
 		{


### PR DESCRIPTION
Removes some calls related to ``symbolDictionary`` to fully use the new ``library`` variable
Changes ``symbolDictionary`` so it no longer exists as an individual variable and now points to ``library.getList()``